### PR TITLE
clean team names

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,7 +26,6 @@ jobs:
           - {os: ubuntu-18.04,   r: 'oldrel/1'}
           - {os: ubuntu-18.04,   r: 'oldrel/2'}
           - {os: ubuntu-18.04,   r: 'oldrel/3'}
-          - {os: ubuntu-18.04,   r: 'oldrel/4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflplotR
 Title: NFL Logo Plots in 'ggplot2'
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: 
     person(given = "Sebastian",
            family = "Carl",
@@ -19,6 +19,7 @@ Imports:
     grid,
     magick (>= 2.7.3),
     magrittr (>= 2.0.0),
+    nflreadr (> 1.1.0.0),
     rlang (>= 0.4.11)
 Suggests: 
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     grid,
     magick (>= 2.7.3),
     magrittr (>= 2.0.0),
-    nflreadr (> 1.1.0.0),
+    nflreadr (>= 1.1.0.01),
     rlang (>= 0.4.11)
 Suggests: 
     testthat (>= 3.0.0)
@@ -27,3 +27,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Remotes:
+    nflverse/nflreadr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,4 @@
 
 * Added the `geom_nfl_logos()` geom.
 * Added the `geom_mean_lines()` and `geom_median_lines()` geoms.
+* `geom_nfl_logos()` now tries to clean the team abbreviations by calling `nflreadr::clean_team_abbrs()`

--- a/R/geom_nfl_logos.R
+++ b/R/geom_nfl_logos.R
@@ -10,7 +10,7 @@
 #' \itemize{
 #'   \item{**x**}{ - The x-coordinate.}
 #'   \item{**y**}{ - The y-coordinate.}
-#'   \item{**team_abbr**}{ - The team abbreviation. Must be one of [`valid_team_names()`].}
+#'   \item{**team_abbr**}{ - The team abbreviation. Should be one of [`valid_team_names()`]. The function tries to clean team names internally by calling [`nflreadr::clean_team_abbrs()`]}
 #'   \item{`alpha = NULL`}{ - The alpha channel, i.e. transparency level, as a numerical value between 0 and 1.}
 #'   \item{`angle = 0`}{ - The angle of the image as a numerical value between 0° and 360°.}
 #'   \item{`hjust = 0.5`}{ - The horizontal adjustment relative to the given x coordinate. Must be a numerical value between 0 and 1.}
@@ -106,9 +106,13 @@ GeomNFL <- ggplot2::ggproto(
   draw_panel = function(data, panel_params, coord, na.rm = FALSE) {
     data <- coord$transform(data, panel_params)
 
+    data$team_abbr <- nflreadr::clean_team_abbrs(data$team_abbr, keep_non_matches = FALSE)
+
     grobs <- lapply(seq_along(data$team_abbr), function(i, urls, alpha, data) {
       team_abbr <- data$team_abbr[i]
-      if (is.null(alpha)) {
+      if (is.na(team_abbr)){
+        grid <- grid::nullGrob()
+      } else if (is.null(alpha)) {
         grid <- grid::rasterGrob(magick::image_read(logo_list[[team_abbr]]))
       } else if (length(alpha) == 1L) {
         if (as.numeric(alpha) <= 0 || as.numeric(alpha) >= 1) {

--- a/man/geom_nfl_logos.Rd
+++ b/man/geom_nfl_logos.Rd
@@ -71,7 +71,7 @@ team abbreviation. The latter can be checked with \code{\link[=valid_team_names]
 \itemize{
 \item{\strong{x}}{ - The x-coordinate.}
 \item{\strong{y}}{ - The y-coordinate.}
-\item{\strong{team_abbr}}{ - The team abbreviation. Must be one of \code{\link[=valid_team_names]{valid_team_names()}}.}
+\item{\strong{team_abbr}}{ - The team abbreviation. Should be one of \code{\link[=valid_team_names]{valid_team_names()}}. The function tries to clean team names internally by calling \code{\link[nflreadr:clean_team_abbrs]{nflreadr::clean_team_abbrs()}}}
 \item{\code{alpha = NULL}}{ - The alpha channel, i.e. transparency level, as a numerical value between 0 and 1.}
 \item{\code{angle = 0}}{ - The angle of the image as a numerical value between 0° and 360°.}
 \item{\code{hjust = 0.5}}{ - The horizontal adjustment relative to the given x coordinate. Must be a numerical value between 0 and 1.}


### PR DESCRIPTION
`geom_nfl_logos()` no cleans team names by calling nflreadr

``` r
library(nflplotR)
library(ggplot2)

team_a <- team_b <- valid_team_names() |> tail(5)
team_a[[6]] <- "WTFFF"

df <- data.frame(
  a = rep(1:6, 1),
  b = sort(rep(1:6, 1), decreasing = TRUE),
  teams = team_a
)

ggplot(df, aes(x = a, y = b)) +
  geom_nfl_logos(aes(team_abbr = teams), width = 0.075) +
  geom_label(aes(label = teams), nudge_y = -0.35, alpha = 0.5) +
  theme_void()
#> Warning: Abbreviations not found in `nflreadr::team_abbr_mapping`: WTFFF
```

![](https://i.imgur.com/Yt910AK.png)
