### PR TITLE
implement combined internal GeomRefLines for easier maintenance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflplotR
 Title: NFL Logo Plots in 'ggplot2'
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: 
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("aut", "cre"))
 Description: A set of functions to visualize National Football League

--- a/R/geom_lines.R
+++ b/R/geom_lines.R
@@ -111,8 +111,6 @@ GeomRefLines <- ggplot2::ggproto("GeomRefLines", ggplot2::Geom,
     colour = "red", size = 0.5, linetype = 2, alpha = NA
   ),
   draw_panel = function(data, panel_params, coord, ref_function, na.rm = FALSE) {
-    data <- data_h <- data_v <- coord$transform(data, panel_params)
-
     args <- names(data)
 
     if (all(!c("v_var", "h_var") %in% args)) {
@@ -121,17 +119,17 @@ GeomRefLines <- ggplot2::ggproto("GeomRefLines", ggplot2::Geom,
     if (!"v_var" %in% args) data$v_var <- NA
     if (!"h_var" %in% args) data$h_var <- NA
 
-    data_v$xintercept <- ref_function(data$v_var, na.rm = na.rm)
-    data_h$yintercept <- ref_function(data$h_var, na.rm = na.rm)
+    data$xintercept <- ref_function(data$v_var, na.rm = na.rm)
+    data$yintercept <- ref_function(data$h_var, na.rm = na.rm)
 
     if (!"v_var" %in% args) {
-      ggplot2::GeomHline$draw_panel(unique(data_h), panel_params, coord)
+      ggplot2::GeomHline$draw_panel(data, panel_params, coord)
     } else if (!"h_var" %in% args) {
-      ggplot2::GeomVline$draw_panel(unique(data_v), panel_params, coord)
+      ggplot2::GeomVline$draw_panel(data, panel_params, coord)
     } else {
       grid::gList(
-        ggplot2::GeomHline$draw_panel(unique(data_h), panel_params, coord),
-        ggplot2::GeomVline$draw_panel(unique(data_v), panel_params, coord)
+        ggplot2::GeomHline$draw_panel(data, panel_params, coord),
+        ggplot2::GeomVline$draw_panel(data, panel_params, coord)
       )
     }
   },

--- a/R/geom_lines.R
+++ b/R/geom_lines.R
@@ -68,11 +68,12 @@ geom_median_lines <- function(mapping = NULL, data = NULL,
     data = data,
     mapping = mapping,
     stat = ggplot2::StatIdentity,
-    geom = GeomMedianLines,
+    geom = GeomRefLines,
     position = ggplot2::PositionIdentity,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      ref_function = stats::median,
       na.rm = na.rm,
       ...
     )
@@ -91,11 +92,12 @@ geom_mean_lines <- function(mapping = NULL, data = NULL,
     data = data,
     mapping = mapping,
     stat = ggplot2::StatIdentity,
-    geom = GeomMeanLines,
+    geom = GeomRefLines,
     position = ggplot2::PositionIdentity,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      ref_function = base::mean,
       na.rm = na.rm,
       ...
     )
@@ -103,58 +105,24 @@ geom_mean_lines <- function(mapping = NULL, data = NULL,
 }
 
 
-GeomMedianLines <- ggplot2::ggproto("GeomMedianLines", ggplot2::Geom,
+GeomRefLines <- ggplot2::ggproto("GeomRefLines", ggplot2::Geom,
   optional_aes = c("v_var", "h_var"),
   default_aes = ggplot2::aes(
     colour = "red", size = 0.5, linetype = 2, alpha = NA
   ),
-  draw_panel = function(data, panel_params, coord, na.rm = FALSE, ...) {
+  draw_panel = function(data, panel_params, coord, ref_function, na.rm = FALSE) {
     data <- data_h <- data_v <- coord$transform(data, panel_params)
 
     args <- names(data)
 
     if (all(!c("v_var", "h_var") %in% args)) {
-      cli::cli_abort("{.var geom_median_lines()} requires at least one of the following aesthetics: {.var v_var}, {.var h_var}")
+      cli::cli_abort("{.var geom_median_lines()} and {.var geom_mean_lines()} require at least one of the following aesthetics: {.var v_var}, {.var h_var}")
     }
     if (!"v_var" %in% args) data$v_var <- NA
     if (!"h_var" %in% args) data$h_var <- NA
 
-    data_v$xintercept <- median(data$v_var, na.rm = na.rm, ...)
-    data_h$yintercept <- median(data$h_var, na.rm = na.rm, ...)
-
-    if (!"v_var" %in% args) {
-      ggplot2::GeomHline$draw_panel(unique(data_h), panel_params, coord)
-    } else if (!"h_var" %in% args) {
-      ggplot2::GeomVline$draw_panel(unique(data_v), panel_params, coord)
-    } else {
-      grid::gList(
-        ggplot2::GeomHline$draw_panel(unique(data_h), panel_params, coord),
-        ggplot2::GeomVline$draw_panel(unique(data_v), panel_params, coord)
-      )
-    }
-  },
-  draw_key = ggplot2::draw_key_path
-)
-
-
-GeomMeanLines <- ggplot2::ggproto("GeomMeanLines", ggplot2::Geom,
-  optional_aes = c("v_var", "h_var"),
-  default_aes = ggplot2::aes(
-    colour = "red", size = 0.5, linetype = 2, alpha = NA
-  ),
-  draw_panel = function(data, panel_params, coord, na.rm = FALSE, ...) {
-    data <- data_h <- data_v <- coord$transform(data, panel_params)
-
-    args <- names(data)
-
-    if (all(!c("v_var", "h_var") %in% args)) {
-      cli::cli_abort("{.var geom_mean_lines()} requires at least one of the following aesthetics: {.var v_var}, {.var h_var}")
-    }
-    if (!"v_var" %in% args) data$v_var <- NA
-    if (!"h_var" %in% args) data$h_var <- NA
-
-    data_v$xintercept <- mean(data$v_var, na.rm = na.rm, ...)
-    data_h$yintercept <- mean(data$h_var, na.rm = na.rm, ...)
+    data_v$xintercept <- ref_function(data$v_var, na.rm = na.rm)
+    data_h$yintercept <- ref_function(data$h_var, na.rm = na.rm)
 
     if (!"v_var" %in% args) {
       ggplot2::GeomHline$draw_panel(unique(data_h), panel_params, coord)

--- a/man/nflplotR-package.Rd
+++ b/man/nflplotR-package.Rd
@@ -8,8 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-A set of functions to visualize National Football League
-    analysis in 'ggplot2'.
+A set of functions to visualize National Football League analysis in 'ggplot2'.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
There have bean two internal Geoms because I wasn't able to pass the mean and median functions on to the draw_panel function. This worked now as I found that the param `na.rm` has to be the last param that is passed on to the Geom