### PR TITLE
don't stack multiple lines on top of each other

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflplotR
 Title: NFL Logo Plots in 'ggplot2'
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Authors@R: 
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("aut", "cre"))
 Description: A set of functions to visualize National Football League

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,3 +9,4 @@
 * Added the function `ggpreview()` which allows to preview a ggplot in it's actual dimensions. (v.0.0.9006)
 * `geom_nfl_logos()` now supports a `colour` aesthetic that colorizes the logos. (v0.0.9007)
 * Added the function `nfl_team_tiers()` that build an NFL team tiers ggplot, thanks to [Timo Riske](https://twitter.com/PFF_Moo) for the suggestion. (v.0.0.9008)
+* Fixed a bug (#10) in `geom_median_lines()` and `geom_mean_lines()` that caused `alpha` to not work properly. (v.0.0.9009)


### PR DESCRIPTION
GeomRefLines now deselects irrelevant aesthetics from data to make sure the underlying Hline and Vline Geoms in ggplot dpon't draw multiple lines on top of each other which would result in alpha appearing to not work properly. 
(Actually alpha works fine but the stacked lines appear non-transparent)

closes #10 